### PR TITLE
support \neq

### DIFF
--- a/src/latex.ts
+++ b/src/latex.ts
@@ -173,6 +173,7 @@ export const latexSymbols = {
     '\\mho': '℧',
     '\\mid': '∣',
     '\\neg': '¬',
+    '\\neq': '≠', 
     '\\nis': '⋼',
     '\\nni': '∌',
     '\\not': '̸',


### PR DESCRIPTION
I usually use `\neq` for not equal, so I added this in using the symbol `≠`.