### PR TITLE
Add support for Coq symbol autocompletion

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
         replaceWithUnicode(vscode.window.activeTextEditor);
     });
 
-    const selector: vscode.DocumentSelector = ['plaintext', 'markdown'];
+    const selector: vscode.DocumentSelector = ['plaintext', 'markdown', 'coq'];
     const provider = new LatexCompletionItemProvider(latexSymbols);
     let completionSub = vscode.languages.registerCompletionItemProvider(selector, provider, '\\');
 


### PR DESCRIPTION
Writing Coq programs often involves using unicode characters and so it's convenient to make them directly available after pressing backslash.