### PR TITLE
fix: Make gen_latex.jl runnable using Julia 0.7 or later

### DIFF
--- a/src/scripts/gen_latex.jl
+++ b/src/scripts/gen_latex.jl
@@ -1,7 +1,13 @@
+if VERSION < v"0.7.0"
+  using Base.REPLCompletions: latex_symbols
+else
+  using REPL.REPLCompletions: latex_symbols
+end
+
 open(joinpath(dirname(@__FILE__), "..", "latex.ts"), "w") do f
   println(f, "export const latexSymbols = {")
   # sort by name length and name content
-  symbols = sort(collect(Base.REPLCompletions.latex_symbols))
+  symbols = sort(collect(latex_symbols))
   symbols = sort(symbols, by=x->length(x[1]))
   for (name, sym) in symbols
     println(f, "    '\\$name': '$sym',")


### PR DESCRIPTION
Hi @ojsheikh,

It seems that `REPLCompletions` was moved from `Base` to `REPL` since Julia 0.7 so `gen_latex.jl` does not work in newer Julia. This version checking resolves the problem.

Confirmed Julia versions:
- Julia 0.6.4
- Julia 0.7.0
- Julia 1.0.3
- Julia 1.1.0

Thanks for creating a great extension!