### PR TITLE
Update hbar to U+210F from U+0127

### DIFF
--- a/src/latex.ts
+++ b/src/latex.ts
@@ -276,7 +276,7 @@ export const latexSymbols = {
     '\\geqq': '≧',
     '\\gneq': '⪈',
     '\\gtcc': '⪧',
-    '\\hbar': 'ħ',
+    '\\hbar': 'ℏ',
     '\\iint': '∬',
     '\\intx': '⨘',
     '\\iota': 'ι',


### PR DESCRIPTION
The correct unicode character is ℏ https://www.compart.com/en/unicode/U+210F "Planck Constant Over Two Pi".

However, previously the character was set to ħ https://www.compart.com/en/unicode/U+0127 "Latin Small Letter H with Stroke".