### PR TITLE
correct Unicode character \varepsilon

### DIFF
--- a/src/latex.ts
+++ b/src/latex.ts
@@ -1846,7 +1846,7 @@ export const latexSymbols = {
     '\\upoldkoppa': 'ϙ',
     '\\upuparrows': '⇈',
     '\\urtriangle': '◹',
-    '\\varepsilon': 'ɛ',
+    '\\varepsilon': 'ε',
     '\\varhexagon': '⬡',
     '\\varnothing': '∅',
     '\\veemidvert': '⩛',


### PR DESCRIPTION
The correct Unicode character should be ε

The original ɛ (Open-mid front unrounded vowel) is not correct Unicode.